### PR TITLE
Auth changes, pass in token as function param

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^README\.Rmd$
 ^\.github$
 ^Makefile$
+^\.lintr$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,8 +1,4 @@
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request]
 
 name: R-CMD-check
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, auth-change]
+  pull_request:
+    branches: [main, auth-change]
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,4 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
     branches: [main, auth-change]

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,2 @@
+linters: linters_with_defaults() # see vignette("lintr")
+encoding: "UTF-8"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.1.0
+Version: 0.1.0.91
 Authors@R: 
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))

--- a/R/auth.R
+++ b/R/auth.R
@@ -27,10 +27,6 @@ proof_header <- function(token = NULL) {
 #' @inheritSection proof_status Timeout
 #' @return A single token (character) for bearer authentication with
 #' the PROOF API
-#' @examples
-#' # Sys.getenv("PROOF_TOKEN")
-#' # x <- proof_authenticate("username", "password")
-#' # Sys.getenv("PROOF_TOKEN")
 proof_authenticate <- function(username, password) {
   assert(username, "character")
   assert(password, "character")
@@ -46,6 +42,5 @@ proof_authenticate <- function(username, password) {
   stop_for_status(response)
   parsed <- content(response, as = "parsed")
   token <- parsed$token
-  Sys.setenv(PROOF_TOKEN = token)
   token
 }

--- a/R/cancel.R
+++ b/R/cancel.R
@@ -1,16 +1,17 @@
 #' Cancel/stop PROOF Cromwell server
 #'
 #' @export
+#' @inheritParams proof_start
 #' @references <https://github.com/FredHutch/proof-api#delete-cromwell-server>
 #' @inheritSection proof_status Timeout
 #' @return On success, a list with a single field:
 #' - `message` (character)
 #'
 #' If run when there's no Cromwell server running, an HTTP error
-proof_cancel <- function() {
+proof_cancel <- function(token = NULL) {
   response <- DELETE(
     make_url("cromwell-server"),
-    proof_header(),
+    proof_header(token),
     timeout(proofr_env$timeout_sec)
   )
   stop_for_message(response)

--- a/R/start.R
+++ b/R/start.R
@@ -5,6 +5,11 @@
 #' is the last name of the PI and f is the first name, e.g., "Jane Doe"
 #' would be `doe_j`; only needed if user is in more than one SLURM account.
 #' optional
+#' @param token (character) token for bearer authentication with
+#' the PROOF API. default is `NULL`. we do not recommend passing your token
+#' here as a string. Either pass it using [Sys.getenv()] or save your
+#' token as an env var and then passing nothing to this param and we'll find
+#' it
 #' @references <https://github.com/FredHutch/proof-api/#post-cromwell-server>
 #' @details Does not return PROOF/Cromwell server URL, for that you have to
 #' periodically call [proof_status()], or wait for the email from the
@@ -20,10 +25,10 @@
 #' @return A list with fields:
 #' - `job_id` (character) - the job ID
 #' - `info` (character) - message
-proof_start <- function(slurm_account = NULL) {
+proof_start <- function(slurm_account = NULL, token = NULL) {
   response <- POST(
     make_url("cromwell-server"),
-    proof_header(),
+    proof_header(token),
     body = list(slurm_account = slurm_account),
     encode = "json",
     timeout(proofr_env$timeout_sec)

--- a/R/status.R
+++ b/R/status.R
@@ -1,6 +1,7 @@
 #' Get PROOF API job status - is job running, what's its URL...
 #'
 #' @export
+#' @inheritParams proof_start
 #' @references <https://github.com/FredHutch/proof-api#get-cromwell-server>
 #' @section Timeout:
 #' If the PROOF API is unavailable, this function will timeout after
@@ -15,10 +16,10 @@
 #' server not running
 #' - `jobInfo` (list): metadata on the Cromwell server. All slots `NULL`
 #' if server not running
-proof_status <- function() {
+proof_status <- function(token = NULL) {
   response <- GET(
     make_url("cromwell-server"),
-    proof_header(),
+    proof_header(token),
     timeout(proofr_env$timeout_sec)
   )
   stop_for_message(response)

--- a/man/proof_authenticate.Rd
+++ b/man/proof_authenticate.Rd
@@ -25,8 +25,3 @@ If the PROOF API is unavailable, this function will timeout after
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 
-\examples{
-# Sys.getenv("PROOF_TOKEN")
-# x <- proof_authenticate("username", "password")
-# Sys.getenv("PROOF_TOKEN")
-}

--- a/man/proof_cancel.Rd
+++ b/man/proof_cancel.Rd
@@ -4,7 +4,14 @@
 \alias{proof_cancel}
 \title{Cancel/stop PROOF Cromwell server}
 \usage{
-proof_cancel()
+proof_cancel(token = NULL)
+}
+\arguments{
+\item{token}{(character) token for bearer authentication with
+the PROOF API. default is \code{NULL}. we do not recommend passing your token
+here as a string. Either pass it using \code{\link[=Sys.getenv]{Sys.getenv()}} or save your
+token as an env var and then passing nothing to this param and we'll find
+it}
 }
 \value{
 On success, a list with a single field:

--- a/man/proof_start.Rd
+++ b/man/proof_start.Rd
@@ -4,13 +4,19 @@
 \alias{proof_start}
 \title{Start PROOF Cromwell server}
 \usage{
-proof_start(slurm_account = NULL)
+proof_start(slurm_account = NULL, token = NULL)
 }
 \arguments{
 \item{slurm_account}{(character) PI name in the form \code{last_f}, where last
 is the last name of the PI and f is the first name, e.g., "Jane Doe"
 would be \code{doe_j}; only needed if user is in more than one SLURM account.
 optional}
+
+\item{token}{(character) token for bearer authentication with
+the PROOF API. default is \code{NULL}. we do not recommend passing your token
+here as a string. Either pass it using \code{\link[=Sys.getenv]{Sys.getenv()}} or save your
+token as an env var and then passing nothing to this param and we'll find
+it}
 }
 \value{
 A list with fields:

--- a/man/proof_status.Rd
+++ b/man/proof_status.Rd
@@ -4,7 +4,14 @@
 \alias{proof_status}
 \title{Get PROOF API job status - is job running, what's its URL...}
 \usage{
-proof_status()
+proof_status(token = NULL)
+}
+\arguments{
+\item{token}{(character) token for bearer authentication with
+the PROOF API. default is \code{NULL}. we do not recommend passing your token
+here as a string. Either pass it using \code{\link[=Sys.getenv]{Sys.getenv()}} or save your
+token as an env var and then passing nothing to this param and we'll find
+it}
 }
 \value{
 A list with fields:

--- a/vignettes/proofr.Rmd
+++ b/vignettes/proofr.Rmd
@@ -28,9 +28,12 @@ proof_authenticate("username", "password")
 
 (note: the above token is not a real token)
 
-The token is not only returned but is set as an environment variable within the R session. This is important as it's not a good security practice to pass secrets such as API tokens as parameters to functions.
+On your computer, save your API token as an environment variable named `PROOF_TOKEN`.
 
-That is to say, please do save your API token as an environment variable somewhere on your computer, but you shouldn't need it after running `proof_authenticate()` because we'll look for it as an environment variable.
+If you've saved your `PROOF_TOKEN` env var, then you can use the other `proofr` functions.
+
+Otherwise, you can pass your PROOF token to the `proofr` functions. If you pass your token to the functions, only do so by passing the call to `Sys.getenv` like `proof_status(token = Sys.getenv("MY_TOKEN"))`.
+
 
 ## Start a Cromwell Server
 

--- a/vignettes/proofr.Rmd.og
+++ b/vignettes/proofr.Rmd.og
@@ -26,15 +26,19 @@ library(proofr)
 Run the function `proof_authenticate()`, which calls the PROOF API with your username and password, and returns an API token (an alphanumeric string).
 
 ```{r auth}
-proof_authenticate("username", "password")
+my_proof_token <- proof_authenticate("username", "password")
+my_proof_token
 #> xyGKibGctQ92rmMKKb39q43XgPxGCmrWoX7NZtamTjDP
 ```
 
 (note: the above token is not a real token)
 
-The token is not only returned but is set as an environment variable within the R session. This is important as it's not a good security practice to pass secrets such as API tokens as parameters to functions.
+On your computer, save your API token as an environment variable named `PROOF_TOKEN`.
 
-That is to say, please do save your API token as an environment variable somewhere on your computer, but you shouldn't need it after running `proof_authenticate()` because we'll look for it as an environment variable.
+If you've saved your `PROOF_TOKEN` env var, then you can use the other `proofr` functions.
+
+Otherwise, you can pass your PROOF token to the `proofr` functions. If you pass your token to the functions, only do so by passing the call to `Sys.getenv` like `proof_status(token = Sys.getenv("MY_TOKEN"))`.
+
 
 ## Start a Cromwell Server
 
@@ -65,13 +69,26 @@ library(rcromwell)
 library(httr)
 ```
 
-Set the Cromwell server URL to be recognized by `rcromwell`
+There are two options for setting the URL in `rcromwell`.
+
+The first option is to set the Cromwell server URL to be recognized by `rcromwell` with `cromwell_config`
 
 ```{r set-url}
 cromwell_config(cromwell_url)
 ```
 
-In addition to setting the Cromwell URL, your PROOF API token is also required for HTTP requests to your server. As long as you've loaded `rcromwell` (via `library(rcromwell)`) and run `proof_authenticate()` successfully, then you should be able to interact with your Cromwell server!
+The other option is to pass the url to each function, for example:
+
+```{r pass-url}
+cromwell_jobs(url = cromwell_url)
+```
+
+In addition to setting the Cromwell URL, your PROOF API token is also required for HTTP requests to your server. After getting your PROOF token you can set it as the env var `PROOF_TOKEN`, or pass it to the `rcromwell` functions, for example:
+
+```{r pass-token}
+cromwell_jobs(url = cromwell_url, token = my_proof_token)
+```
+
 
 ## Interact with the Cromwell server
 
@@ -79,6 +96,8 @@ As an example, `cromwell_version()` checks the version of your Cromwell server
 
 ```{r cromwell-version}
 cromwell_version()
+#> $cromwell
+#> [1] "84"
 ```
 
 See the many functions in [rcromwell documentation](https://getwilds.org/rcromwell/reference/).


### PR DESCRIPTION
fix #11

- `proof_authenticate` by default doesn't set an env var with the token anymore, but user is instructed to do that manually if needed