### PR TITLE
Allow PROOF API base URL to be set to environment variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.2.0.93
+Version: 0.2.0.94
 Authors@R: 
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
-proof_base <- Sys.getenv("PROOF_API_BASE_URL",
-                         "https://proof-api.fredhutch.org")
 
 make_url <- function(...) {
+  proof_base <- Sys.getenv("PROOF_API_BASE_URL",
+    "https://proof-api.fredhutch.org")
   file.path(proof_base, ...)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,4 @@
-proof_base <- "https://proof-api.fredhutch.org"
+proof_base <- Sys.getenv("PROOF_API_BASE_URL", "https://proof-api.fredhutch.org")
 
 make_url <- function(...) {
   file.path(proof_base, ...)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,5 @@
-proof_base <- Sys.getenv("PROOF_API_BASE_URL", "https://proof-api.fredhutch.org")
+proof_base <- Sys.getenv("PROOF_API_BASE_URL",
+                         "https://proof-api.fredhutch.org")
 
 make_url <- function(...) {
   file.path(proof_base, ...)


### PR DESCRIPTION
called `PROOF_API_BASE_URL`. If not set, use the default production URL.

<!-- 
Maintainers: This issue template comes from https://github.com/getwilds/.github
You're encouraged to add your own that's optimized for your repo -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->

* Allow PROOF API base URL to be determined by environment variable `PROOF_API_BASE_URL`. If not set, default to production URL.
* Bump package version

This will enable the the dev instance of the PROOF shiny app to point to the dev instance of the API (see related PR that will appear shortly in PROOF shiny app repo).

