### PR TITLE
remove links to proof api repo since its private

### DIFF
--- a/R/cancel.R
+++ b/R/cancel.R
@@ -2,7 +2,6 @@
 #'
 #' @export
 #' @inheritParams proof_start
-#' @references <https://github.com/FredHutch/proof-api#delete-cromwell-server>
 #' @inheritSection proof_status Timeout
 #' @return On success, a list with a single field:
 #' - `message` (character)

--- a/R/info.R
+++ b/R/info.R
@@ -1,7 +1,6 @@
 #' Get information about PROOF server
 #'
 #' @export
-#' @references <https://github.com/FredHutch/proof-api?tab=readme-ov-file#get-info>
 #' @return A list with fields:
 #' - `branch` (character): git branch of API
 #' - `commit_sha` (character): SHA of the git commit of the API

--- a/R/start.R
+++ b/R/start.R
@@ -10,11 +10,9 @@
 #' here as a string. Either pass it using [Sys.getenv()] or save your
 #' token as an env var and then passing nothing to this param and we'll find
 #' it
-#' @references <https://github.com/FredHutch/proof-api/#post-cromwell-server>
 #' @details Does not return PROOF/Cromwell server URL, for that you have to
 #' periodically call [proof_status()], or wait for the email from the
-#' PROOF API. See the link to proof-api for more details about the
-#' slurm account.
+#' PROOF API
 #' @inheritSection proof_status Timeout
 #' @section Cromwell Server uptime:
 #' The Cromwell server started by this function will run for 7 days

--- a/R/status.R
+++ b/R/status.R
@@ -6,7 +6,6 @@
 #' @param wait (logical) if `TRUE` wait for the server to be ready to
 #' interact with. if `FALSE` return immediately, then you'll want to call
 #' this function again until you get the server URL
-#' @references <https://github.com/FredHutch/proof-api#get-cromwell-server>
 #' @section Timeout:
 #' If the PROOF API is unavailable, this function will timeout after
 #' 5 seconds. Contact the package maintainer if you get a timeout error.

--- a/man/proof_cancel.Rd
+++ b/man/proof_cancel.Rd
@@ -31,6 +31,3 @@ If the PROOF API is unavailable, this function will timeout after
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 
-\references{
-\url{https://github.com/FredHutch/proof-api#delete-cromwell-server}
-}

--- a/man/proof_info.Rd
+++ b/man/proof_info.Rd
@@ -19,6 +19,3 @@ A list with fields:
 \description{
 Get information about PROOF server
 }
-\references{
-\url{https://github.com/FredHutch/proof-api?tab=readme-ov-file#get-info}
-}

--- a/man/proof_start.Rd
+++ b/man/proof_start.Rd
@@ -31,8 +31,7 @@ Start PROOF Cromwell server
 \details{
 Does not return PROOF/Cromwell server URL, for that you have to
 periodically call \code{\link[=proof_status]{proof_status()}}, or wait for the email from the
-PROOF API. See the link to proof-api for more details about the
-slurm account.
+PROOF API
 }
 \section{Cromwell Server uptime}{
 
@@ -50,6 +49,3 @@ If the PROOF API is unavailable, this function will timeout after
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 
-\references{
-\url{https://github.com/FredHutch/proof-api/#post-cromwell-server}
-}

--- a/man/proof_status.Rd
+++ b/man/proof_status.Rd
@@ -40,6 +40,3 @@ If the PROOF API is unavailable, this function will timeout after
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 
-\references{
-\url{https://github.com/FredHutch/proof-api#get-cromwell-server}
-}


### PR DESCRIPTION
## Description
Remove links to the proof api repo b/c it's private. Leaving the one reference in the README though. I assume at some point the proof api repo will be public, but don't know when that will be

## Related Issue
fix #13

## Example
N/A

## Testing
N/A, just docs changes