### PR TITLE
fix install line for rcromwell

### DIFF
--- a/vignettes/proofr.Rmd
+++ b/vignettes/proofr.Rmd
@@ -12,7 +12,7 @@ vignette: >
 Load `proofr`
 
 
-```r
+``` r
 library(proofr)
 ```
 
@@ -21,7 +21,7 @@ library(proofr)
 Run the function `proof_authenticate()`, which calls the PROOF API with your username and password, and returns an API token (an alphanumeric string).
 
 
-```r
+``` r
 my_proof_token <- proof_authenticate("username", "password")
 my_proof_token
 #> xyGKibGctQ92rmMKKb39q43XgPxGCmrWoX7NZtamTjDP
@@ -32,7 +32,7 @@ my_proof_token
 Alternatively, save your API token directly as an environment variable named `PROOF_TOKEN` so that it can be used by other `proofr` functions without exposing your token in your code.  To do so, run the following: 
 
 
-```r
+``` r
 Sys.setenv("PROOF_TOKEN" = proof_authenticate("username", "password"))
 ```
 
@@ -41,7 +41,7 @@ Sys.setenv("PROOF_TOKEN" = proof_authenticate("username", "password"))
 Start a PROOF server using the `proof_start()` function:
 
 
-```r
+``` r
 proof_start()
 ```
 Note: `proofr` assumes you only have one server running; if you've started a server using the app, you'll need to stop that server before starting one in R via `proofr`. 
@@ -49,7 +49,7 @@ Note: `proofr` assumes you only have one server running; if you've started a ser
 Get metadata about the PROOF server you have started, including the URL of the API, using `wait=TRUE` so that it doesn't return data until the server is fully ready to use.  
 
 
-```r
+``` r
 metadata <- proof_status(wait = TRUE)
 cromwell_url <- metadata$cromwellUrl
 cromwell_url
@@ -60,10 +60,10 @@ cromwell_url
 Load  `rcromwell`
 
 
-```r
+``` r
 if (!requireNamespace("rcromwell", quietly=TRUE)) {
   install.packages("pak")
-  pak::pak("rcromwell")
+  pak::pak("getwilds/rcromwell")
 }
 library(rcromwell)
 library(httr)
@@ -74,21 +74,21 @@ There are two options for setting the URL in `rcromwell`.
 The first option is to set the Cromwell server URL to be recognized by `rcromwell` with `cromwell_config`
 
 
-```r
+``` r
 cromwell_config(cromwell_url)
 ```
 
 The other option is to pass the url to each function, for example:
 
 
-```r
+``` r
 cromwell_jobs(url = cromwell_url)
 ```
 
 In addition to setting the Cromwell URL, your PROOF API token is also required for HTTP requests to your server. After getting your PROOF token you can set it as the env var `PROOF_TOKEN`, or pass it to the `rcromwell` functions, for example:
 
 
-```r
+``` r
 cromwell_jobs(url = cromwell_url, token = my_proof_token)
 ```
 
@@ -98,7 +98,7 @@ cromwell_jobs(url = cromwell_url, token = my_proof_token)
 As an example, `cromwell_version()` checks the version of your Cromwell server
 
 
-```r
+``` r
 cromwell_version()
 #> $cromwell
 #> [1] "84"

--- a/vignettes/proofr.Rmd.og
+++ b/vignettes/proofr.Rmd.og
@@ -63,7 +63,7 @@ Load  `rcromwell`
 ```{r setup-rcromwell}
 if (!requireNamespace("rcromwell", quietly=TRUE)) {
   install.packages("pak")
-  pak::pak("rcromwell")
+  pak::pak("getwilds/rcromwell")
 }
 library(rcromwell)
 library(httr)


### PR DESCRIPTION
## Description
changed `pak::pak("rcromwell")` to `pak::pak("getwilds/rcromwell")`

unfortunately a bunch of non-related changes are introduced for fenced code blocks presumably because of a knitr change I'm guessing

## Related Issue
fix #22 

## Example
N/A

## Testing
vignette builds locally