### PR TITLE
proofr v0.4.0 Updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.3.0.96
+Version: 0.4.0.0
 Authors@R: 
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.4.0.0
+Version: 0.4.0
 Authors@R: 
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.3.0.91
+Version: 0.3.0.96
 Authors@R: 
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# proofr v0.4.0
+
+* Bumping timeout from 5 seconds to 20 seconds (@sckott in [direct commit](https://github.com/getwilds/proofr/commit/cbe9062fd73e61992b46035e7ac2241cd8de2541))
+
 # proofr v0.3.0
 
 * Swapping `httr` for `httr2` (@sckott in [#25](https://github.com/getwilds/proofr/pull/25))

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -2,5 +2,5 @@ proofr_env <- new.env() # nocov start
 
 .onLoad <- function(libname, pkgname) {
   # use the same timezone throughout the package
-  proofr_env$timeout_sec <<- 5
+  proofr_env$timeout_sec <<- 20
 } # nocov end

--- a/R/status.R
+++ b/R/status.R
@@ -8,7 +8,7 @@
 #' this function again until you get the server URL
 #' @section Timeout:
 #' If the PROOF API is unavailable, this function will timeout after
-#' 5 seconds. Contact the package maintainer if you get a timeout error.
+#' 20 seconds. Contact the package maintainer if you get a timeout error.
 #' See [proof_timeout()].
 #' @return A list with fields:
 #' - `canJobStart` (logical): can a job to make a Cromwell server be started?

--- a/R/timeout.R
+++ b/R/timeout.R
@@ -2,10 +2,10 @@
 #'
 #' @export
 #' @param sec (integer/numeric) number of seconds after which
-#' requests will timeout. default: 10 sec (10000 ms)
+#' requests will timeout. default: 20 sec (20000 ms)
 #' @references <https://httr.r-lib.org/reference/timeout.html>
 #' @return nothing, side effect of setting the timeout for requests
-proof_timeout <- function(sec = 10) {
+proof_timeout <- function(sec = 20) {
   assert(sec, c("integer", "numeric"))
   proofr_env$timeout_sec <- sec
 }

--- a/man/proof_authenticate.Rd
+++ b/man/proof_authenticate.Rd
@@ -27,7 +27,7 @@ pull in your password from an environment variable stored outside of R like
 \section{Timeout}{
 
 If the PROOF API is unavailable, this function will timeout after
-5 seconds. Contact the package maintainer if you get a timeout error.
+20 seconds. Contact the package maintainer if you get a timeout error.
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 

--- a/man/proof_cancel.Rd
+++ b/man/proof_cancel.Rd
@@ -27,7 +27,7 @@ Cancel/stop PROOF Cromwell server
 \section{Timeout}{
 
 If the PROOF API is unavailable, this function will timeout after
-5 seconds. Contact the package maintainer if you get a timeout error.
+20 seconds. Contact the package maintainer if you get a timeout error.
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 

--- a/man/proof_start.Rd
+++ b/man/proof_start.Rd
@@ -45,7 +45,7 @@ retrieve data.
 \section{Timeout}{
 
 If the PROOF API is unavailable, this function will timeout after
-5 seconds. Contact the package maintainer if you get a timeout error.
+20 seconds. Contact the package maintainer if you get a timeout error.
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 

--- a/man/proof_status.Rd
+++ b/man/proof_status.Rd
@@ -36,7 +36,7 @@ Get PROOF API job status - is job running, what's its URL...
 \section{Timeout}{
 
 If the PROOF API is unavailable, this function will timeout after
-5 seconds. Contact the package maintainer if you get a timeout error.
+20 seconds. Contact the package maintainer if you get a timeout error.
 See \code{\link[=proof_timeout]{proof_timeout()}}.
 }
 

--- a/man/proof_timeout.Rd
+++ b/man/proof_timeout.Rd
@@ -4,11 +4,11 @@
 \alias{proof_timeout}
 \title{Set the timeout for all requests to the PROOF API}
 \usage{
-proof_timeout(sec = 10)
+proof_timeout(sec = 20)
 }
 \arguments{
 \item{sec}{(integer/numeric) number of seconds after which
-requests will timeout. default: 10 sec (10000 ms)}
+requests will timeout. default: 20 sec (20000 ms)}
 }
 \value{
 nothing, side effect of setting the timeout for requests


### PR DESCRIPTION
## Description
- Bumping timeout from 5 seconds to 20 seconds (@sckott in [direct commit](https://github.com/getwilds/proofr/commit/cbe9062fd73e61992b46035e7ac2241cd8de2541))

## Related Issues
- Fixes #36

## Testing & Examples
- Minor enough impact to not require testing