### PR TITLE
support regulated_data param in proof_start()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: proofr
 Title: Client for the PROOF API
-Version: 0.4.0
-Authors@R: 
+Version: 0.4.1
+Authors@R:
     person("Scott", "Chamberlain", , "sachamber@fredhutch.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135"))
 Description: Client for the PROOF API.
@@ -15,7 +15,7 @@ Imports:
     cli,
     glue,
     httr2
-Suggests: 
+Suggests:
     jsonlite,
     knitr,
     rmarkdown,

--- a/R/start.R
+++ b/R/start.R
@@ -25,7 +25,8 @@
 #' @return A list with fields:
 #' - `job_id` (character) - the job ID =
 #' - `info` (character) - message
-proof_start <- function(slurm_account = NULL, token = NULL, regulated_data = FALSE) {
+proof_start <- function(slurm_account = NULL,
+                        token = NULL, regulated_data = FALSE) {
   request(make_url("cromwell-server")) |>
     req_body_json(list(slurm_account = slurm_account, regulated_data = regulated_data)) |>
     proof_header(token) |>

--- a/R/start.R
+++ b/R/start.R
@@ -29,7 +29,7 @@ proof_start <- function(slurm_account = NULL,
                         token = NULL, regulated_data = FALSE) {
   request(make_url("cromwell-server")) |>
     req_body_json(list(slurm_account = slurm_account,
-                 regulated_data = regulated_data)) |>
+                       regulated_data = regulated_data)) |>
     proof_header(token) |>
     req_timeout(proofr_env$timeout_sec) |>
     req_error(body = error_body) |>

--- a/R/start.R
+++ b/R/start.R
@@ -10,6 +10,8 @@
 #' here as a string. Either pass it using [Sys.getenv()] or save your
 #' token as an env var and then passing nothing to this param and we'll find
 #' it
+#' @param regulated_data (logical) whether to use a scratch directory
+#' in regulated storage.
 #' @details Does not return PROOF/Cromwell server URL, for that you have to
 #' periodically call [proof_status()], or wait for the email from the
 #' PROOF API
@@ -23,9 +25,9 @@
 #' @return A list with fields:
 #' - `job_id` (character) - the job ID
 #' - `info` (character) - message
-proof_start <- function(slurm_account = NULL, token = NULL) {
+proof_start <- function(slurm_account = NULL, token = NULL, regulated_data = FALSE) {
   request(make_url("cromwell-server")) |>
-    req_body_json(list(slurm_account = slurm_account)) |>
+    req_body_json(list(slurm_account = slurm_account, regulated_data = regulated_data)) |>
     proof_header(token) |>
     req_timeout(proofr_env$timeout_sec) |>
     req_error(body = error_body) |>

--- a/R/start.R
+++ b/R/start.R
@@ -28,7 +28,8 @@
 proof_start <- function(slurm_account = NULL,
                         token = NULL, regulated_data = FALSE) {
   request(make_url("cromwell-server")) |>
-    req_body_json(list(slurm_account = slurm_account, regulated_data = regulated_data)) |>
+    req_body_json(list(slurm_account = slurm_account,
+                 regulated_data = regulated_data)) |>
     proof_header(token) |>
     req_timeout(proofr_env$timeout_sec) |>
     req_error(body = error_body) |>

--- a/R/start.R
+++ b/R/start.R
@@ -23,7 +23,7 @@
 #' You do however need to have a Cromwell server up and running to
 #' retrieve data.
 #' @return A list with fields:
-#' - `job_id` (character) - the job ID
+#' - `job_id` (character) - the job ID =
 #' - `info` (character) - message
 proof_start <- function(slurm_account = NULL, token = NULL, regulated_data = FALSE) {
   request(make_url("cromwell-server")) |>

--- a/man/proof_start.Rd
+++ b/man/proof_start.Rd
@@ -4,7 +4,7 @@
 \alias{proof_start}
 \title{Start PROOF Cromwell server}
 \usage{
-proof_start(slurm_account = NULL, token = NULL)
+proof_start(slurm_account = NULL, token = NULL, regulated_data = FALSE)
 }
 \arguments{
 \item{slurm_account}{(character) PI name in the form \code{last_f}, where last
@@ -17,11 +17,14 @@ the PROOF API. default is \code{NULL}. we do not recommend passing your token
 here as a string. Either pass it using \code{\link[=Sys.getenv]{Sys.getenv()}} or save your
 token as an env var and then passing nothing to this param and we'll find
 it}
+
+\item{regulated_data}{(logical) whether to use a scratch directory
+in regulated storage.}
 }
 \value{
 A list with fields:
 \itemize{
-\item \code{job_id} (character) - the job ID
+\item \code{job_id} (character) - the job ID =
 \item \code{info} (character) - message
 }
 }


### PR DESCRIPTION
<!-- 
Maintainers: This issue template comes from https://github.com/getwilds/.github
You're encouraged to add your own that's optimized for your repo 

Is this a PR to main branch (or whatever the default branch is called)?
- Code can only be added to main via PR
- A project lead has to approve a PR to main
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Modified `proof_start()` to have a `regulated_data` parameter, defaulting to `FALSE`.
This goes with the [PR](https://github.com/FredHutch/proof-api/pull/139) to the PROOF API that now takes such a parameter. 


<!-- Describe your changes -->



## Testing
<!-- If the repo has tests, mention if you ran them and whether
they passed or not. Include screenshots if appropriate. In some
repos GitHub Actions will run tests and you will see those results
below -->

Here is how I tested the functionality:

I set the `PROOF_API_BASE_URL` environment variable to point to my development instance
of the PROOF API. Others can set this to the dev instance of the PROOF API, but only once the PR referenced above has been merged into dev.

Then I installed the package from the branch including this change:

```
R CMD INSTALL .
```

Then ran the following in R:

```R
library(proofr)
ret <- proof_start("scicomp", "XXX-my-redacted-token-XXX", regulated_data=TRUE)
```

Once the server is running, I verify that the scratch directory is in the regulated area:

```R
proof_status(FALSE, "XXX-my-redacted-token-XXX")$jobInfo$SCRATCHDIR
```

I also ran without specifying the `regulated_data` param:

```R
ret <- proof_start("scicomp", "XXX-my-redacted-token-XXX")
```

Then again ran `proof_status()` as above; this time it showed the scratch dir in the expected, default place.
